### PR TITLE
Unify API

### DIFF
--- a/src/smote.jl
+++ b/src/smote.jl
@@ -140,31 +140,21 @@ function _col2int(data, col::Union{Symbol,AbstractString})
     return index
 end
 
-function _vcat_tables(A, B)
-    header = Tables.columnnames(A)
-    @assert all(header .== Tables.columnnames(B)) "$header != $(Tables.columnnames(B))"
-    ncols = length(header)
-    nrows = Tables.rowcount(A) + Tables.rowcount(B)
-    mat = Matrix{Real}(undef, nrows, ncols)
-    for i in 1:length(header)
-        a = Tables.getcolumn(A, header[i])
-        b = Tables.getcolumn(B, header[i])
-        col = vcat(a, b)
-        mat[:, i] = col
-    end
-    return Tables.table(mat; header)
-end
-
 """
-    smote(rng::AbstractRNG, data, col::Union{AbstractString,Symbol}; ratio::Real=1.0, k::Union{Nothing,Int}=nothing)
+    smote(rng::AbstractRNG, data, col::Union{Int,AbstractString,Symbol}; ratio::Real=1.0, k::Union{Nothing,Int}=nothing)
     smote(data, col::Union{AbstractString,Symbol}; ratio::Real=1.0, k::Union{Nothing,Int}=nothing)
 
-Return a copy of `data` where the ratio between elements in `col` satisfies `ratio`.
 This is a helper function to simplify balancing `data`.
-Here, `ratio` specifies the desired ratio between the element types in `col`.
-For example, when column `:class` contains 1200 elements of class 1 and 1400 elements of class 2, then `smote(data, :class; ratio=1.0)` will add 200 elements of class 1.
-With a ratio of 0.9, smote will add only 60 elements since class 1 comes first in the data and 1400 * 0.9 = 1260 assuming that class 1 comes first in the data and then class 2.
-If class 2 would come first, then the ratio of 0.9 will fail since it would need to remove elements from class 1.
+Return the sample obtained via Synthetic Minority Over-sampling TEchnique (SMOTE) for
+
+- `data`: Data as a matrix or satisfying the tables interface. For matices, each column denotes a point and for tables each row denotes a point.
+- `col`: A column number or name specifying on which column the oversampling needs to be based.
+- `ratio`:
+    Here, `ratio` specifies the desired ratio between the element types in `col`.
+    For example, when column `:class` contains 1200 elements of class 1 and 1400 elements of class 2, then `smote(data, :class; ratio=1.0)` will add 200 elements of class 1.
+    With a ratio of 0.9, smote will add only 60 elements since class 1 comes first in the data and 1400 * 0.9 = 1260 assuming that class 1 comes first in the data and then class 2.
+    If class 2 would come first, then the ratio of 0.9 will fail since it would need to remove elements from class 1.
+- `k`: Number of nearest neighbors to consider for each point.
 
 !!! note
     This functionality is currently only implemented for 2 classes.
@@ -197,9 +187,7 @@ function smote(
         header = Tables.columnnames(data)
         Tables.table(minority_data; header)
     end
-    new = smote(rng, minority, n; k)
-    new_table = Tables.columntable(new)
-    return _vcat_tables(data, new_table)
+    return smote(rng, minority, n; k)
 end
 function smote(data, col::Union{AbstractString,Symbol}; ratio::Real=1.0, k::Union{Nothing,Int}=nothing)
     return smote(default_rng(), data, col; ratio, k)

--- a/test/smote.jl
+++ b/test/smote.jl
@@ -54,14 +54,14 @@ end
         @inferred Resample._col2int(data, :class)
     end
 
-    new = (; X=[2], class=[2])
-    @test Resample._vcat_tables(data, new).X == [1, 2, 1, 2, 1, 2]
-
-    @test smote(data, :class).class == [1, 2, 1, 2, 1, 2]
+    out = smote(data, :class)
+    @test out.X == [2.0]
+    @test out.class == [2.0]
 end
 
 @testset "dataframes" begin
     data = DataFrame(; X=[1, 2, 1, 2, 1], class=[1, 2, 1, 2, 1])
     out = DataFrame(smote(data, :class))
-    @test out.class == [1, 2, 1, 2, 1, 2]
+    combined = vcat(data, out)
+    @test combined.class == [1, 2, 1, 2, 1, 2]
 end


### PR DESCRIPTION
The new and yet unregistered method for `smote(...; ratio, ...)` was inconsistent with the other methods for `smote` since it returned a combined dataset containing the input data and the new synthetic instead of only the new data. This PR fixes that inconsistency.

Now it also only returns the new data. A combined dataset would be slightly more convenient, but it is much harder to get only the new data from that than it is to join the new data to the old.